### PR TITLE
Add large prop to ProductName

### DIFF
--- a/react/components/product-details/CHANGELOG.md
+++ b/react/components/product-details/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Initial version of the shipping simulator.
 
+### Changed
+
+* Add large prop to ProductName component.
+
 ## [1.2.10] - 2018-05-08
 
 ### Changed

--- a/react/components/product-details/src/ProductName.js
+++ b/react/components/product-details/src/ProductName.js
@@ -1,31 +1,47 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import './product-name.css'
+
 /**
  * Name component. Show name and relevant SKU information of the Product Summary
  */
 class ProductName extends Component {
+  static propTypes = {
+    /** Name of the product */
+    name: PropTypes.string.isRequired,
+    /** Selected SKU name */
+    skuName: PropTypes.string,
+    /** Brand name */
+    brandName: PropTypes.string,
+    /** Display large font */
+    large: PropTypes.boolean,
+  }
+
+  static defaultProps = {
+    large: false,
+  }
+
   render() {
-    const { name, skuName, brandName } = this.props
+    const { name, skuName, brandName, large } = this.props
+
+    let brandClasses = 'vtex-product-name__brand'
+    let skuClasses = 'vtex-product-name__sku'
+
+    if (large) {
+      brandClasses += ' vtex-product-name__brand--large'
+      skuClasses += ' vtex-product-name__sku--large'
+    }
 
     return (
-      <div className="vtex-product-name overflow-hidden">
-        <div className="vtex-product-name__brand f5">
+      <div className="vtex-product-name">
+        <div className={brandClasses}>
           {name} {brandName && `(${brandName})`}
         </div>
-        <div className="f6">{skuName}</div>
+        <div className={skuClasses}>{skuName}</div>
       </div>
     )
   }
-}
-
-ProductName.propTypes = {
-  /** Name of the product */
-  name: PropTypes.string.isRequired,
-  /** Selected SKU name */
-  skuName: PropTypes.string,
-  /** Brand name */
-  brandName: PropTypes.string,
 }
 
 export default ProductName

--- a/react/components/product-details/src/product-name.css
+++ b/react/components/product-details/src/product-name.css
@@ -1,0 +1,15 @@
+.vtex-product-name {
+  overflow: hidden;
+}
+
+.vtex-product-name__brand {
+  font-size: 1rem;
+}
+
+.vtex-product-name__brand--large {
+  font-size: 2.25rem;
+}
+
+.vtex-product-name__sku {
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `large` prop to `ProductName` component.

#### What problem is this solving?
In the some cases, the product name must vary in size, such as in the product details page.

#### How should this be manually tested?
```jsx
<ProductName {...otherProps} large />
```

#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
