### PR TITLE
Fix footer schema

### DIFF
--- a/react/components/Footer/components/FooterPaymentFormList.js
+++ b/react/components/Footer/components/FooterPaymentFormList.js
@@ -24,6 +24,7 @@ class FooterPaymentFormItem extends Component {
     return <img className="vtex-footer__payment-form-item" src={image} />
   }
 }
+
 FooterPaymentFormItem.displayName = 'FooterPaymentFormItem'
 
 FooterPaymentFormItem.propTypes = {

--- a/react/components/Footer/index.js
+++ b/react/components/Footer/index.js
@@ -48,7 +48,7 @@ const paymentFormSchema = {
       enum: [
         'MasterCard',
         'Visa',
-        'Diners',
+        'Diners Club',
       ],
     },
   },

--- a/react/components/Footer/propTypes.js
+++ b/react/components/Footer/propTypes.js
@@ -11,7 +11,7 @@ export const objectLikeBadgeArray = PropTypes.objectOf(PropTypes.shape({
 
 export const objectLikePaymentFormArray = PropTypes.objectOf(PropTypes.shape({
   paymentType: PropTypes.oneOf([
-    'MasterCard', 'Visa', 'American Express', 'Diners', 'Elo', 'Boleto',
+    'MasterCard', 'Visa', 'Diners Club',
   ]),
 }))
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix footer schema for the payment type.

#### What problem is this solving?
The footer schema was wrong and wasn't displaying the image of the `Diners Club` payment type.

#### How should this be manually tested?
(Workspace)[https://dreamstore-lucas--storecomponents.myvtex.com/].

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/39939205-d5aaa6a0-552b-11e8-9010-1e88ee98178f.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
