### PR TITLE
Add enter keypress to the search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * Add all `product-details` components to Apps.
-* Enter key press to the `search bar`
+* Add `Enter key` press to the `search bar`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * Add all `product-details` components to Apps.
+* Enter key press to the `search bar`
 
 ### Changed
 

--- a/react/components/search-bar/src/index.js
+++ b/react/components/search-bar/src/index.js
@@ -10,6 +10,14 @@ import './global.css'
 
 /** Canonical search bar that uses the autocomplete endpoint to search for a specific product*/
 export default class SearchBar extends Component {
+  // TODO: This redirect should be changed to react navigation
+  // frameworks, like React Router or another approach.
+  handlerEnterPress(event) {
+    if (event.key === 'Enter') {
+      window.location = `${event.target.value}/s`
+    }
+  }
+
   render() {
     const { placeholder, emptyPlaceholder } = this.props
     return (
@@ -24,7 +32,7 @@ export default class SearchBar extends Component {
             isOpen,
           }) => (
             <div className="relative">
-              <AutocompleteInput {...getInputProps({ placeholder })} />
+              <AutocompleteInput {...getInputProps({ placeholder })} onKeyDown={this.handlerEnterPress} />
               {isOpen && inputValue !== '' ? (
                 <ResultsLits
                   {...{


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add enter keypress to the search bar

#### What problem is this solving?
The search bar wasn't searching when the `Enter` key is pressed.

#### How should this be manually tested?
https://andre--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
