### PR TITLE
Fix slider classNames

### DIFF
--- a/react/components/slider/index.js
+++ b/react/components/slider/index.js
@@ -10,9 +10,9 @@ import getItemsPerPage from './getItemsPerPage'
 import './global.css'
 
 const VTEXClasses = {
-  ARROW_RIGHT_CLASS: 'vtex-slick-slider__arrow-right',
-  ARROW_LEFT_CLASS: 'vtex-slick-slider__arrow-left',
-  DOTS_CLASS: 'vtex-slick-slider__dots',
+  ARROW_RIGHT_CLASS: 'vtex-slider__arrow-right',
+  ARROW_LEFT_CLASS: 'vtex-slider__arrow-left',
+  DOTS_CLASS: 'vtex-slider__dots',
 }
 
 /**


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix Slider classNames (change `.vtex-slick-slider` to `.vtex-slider`)

https://carouselslider--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
